### PR TITLE
Fix sequence_in_order operator parameter structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ asserts:
 Validates that expected string items appear in order within the top N items of a list. Additional items can appear between expected items, but the expected items must maintain their specified order.
 
 **Parameters:**
-- `expected` (list[str]): List of strings that must appear in order
-- `limit` (int): Number of top items from the selection to evaluate
+- `expected` (object): Object containing:
+  - `data` (list[str]): List of strings that must appear in order
+  - `limit` (int): Number of top items from the selection to evaluate
 
 **Use case:** Validate event logs, sequential data, or process steps where order matters but noise is expected.
 
@@ -229,19 +230,21 @@ asserts:
   - path: $.events[*].type
     op: sequence_in_order
     expected:
-      - "START"
-      - "PROCESSING"
-      - "COMPLETE"
-    limit: 10
+      data:
+        - "START"
+        - "PROCESSING"
+        - "COMPLETE"
+      limit: 10
 
   # Validate log messages appear in correct sequence
   - path: $.logs[*].level
     op: sequence_in_order
     expected:
-      - "INFO"
-      - "WARNING"
-      - "ERROR"
-    limit: 20
+      data:
+        - "INFO"
+        - "WARNING"
+        - "ERROR"
+      limit: 20
 ```
 
 ### Assertion Composition

--- a/src/result_evaluator/runtime/operators.py
+++ b/src/result_evaluator/runtime/operators.py
@@ -89,21 +89,45 @@ def op_sequence_in_order(selection: Any, params: dict[str, Any]) -> OpResult:
     # Validate required parameters
     if "expected" not in params:
         return OpResult(False, "Missing required parameter 'expected'", selection)
-    if "limit" not in params:
-        return OpResult(False, "Missing required parameter 'limit'", selection)
 
-    expected = params["expected"]
-    limit = params["limit"]
+    expected_obj = params["expected"]
 
     # Auto-convert single items to list
     if not isinstance(selection, list):
         selection = [str(selection)]
 
-    # Validate expected is a list
+    # Validate expected is a dict with 'data' and 'limit' fields
+    if not isinstance(expected_obj, dict):
+        return OpResult(
+            False,
+            f"Parameter 'expected' must be a dict with 'data' and 'limit' fields, got {type(expected_obj).__name__}",
+            selection,
+        )
+
+    # Validate 'data' field exists
+    if "data" not in expected_obj:
+        return OpResult(
+            False,
+            "Parameter 'expected' must contain 'data' field",
+            selection,
+        )
+
+    # Validate 'limit' field exists
+    if "limit" not in expected_obj:
+        return OpResult(
+            False,
+            "Parameter 'expected' must contain 'limit' field",
+            selection,
+        )
+
+    expected = expected_obj["data"]
+    limit = expected_obj["limit"]
+
+    # Validate expected data is a list
     if not isinstance(expected, list):
         return OpResult(
             False,
-            f"Parameter 'expected' must be a list, got {type(expected).__name__}",
+            f"Parameter 'expected.data' must be a list, got {type(expected).__name__}",
             selection,
         )
 
@@ -111,7 +135,7 @@ def op_sequence_in_order(selection: Any, params: dict[str, Any]) -> OpResult:
     if not isinstance(limit, int) or limit <= 0:
         return OpResult(
             False,
-            f"Parameter 'limit' must be a positive integer, got {limit}",
+            f"Parameter 'expected.limit' must be a positive integer, got {limit}",
             selection,
         )
 
@@ -124,7 +148,7 @@ def op_sequence_in_order(selection: Any, params: dict[str, Any]) -> OpResult:
         if not isinstance(item, str):
             return OpResult(
                 False,
-                f"All items in 'expected' must be strings, found {type(item).__name__}",
+                f"All items in 'expected.data' must be strings, found {type(item).__name__}",
                 selection,
             )
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -295,7 +295,7 @@ def test_op_match_regex_dict_input() -> None:
 def test_op_sequence_in_order_basic_match() -> None:
     """Test op_sequence_in_order with basic sequence match with interleaved items."""
     result = op_sequence_in_order(
-        ["A", "X", "B", "Y", "Z", "C", "D"], {"expected": ["A", "B", "C"], "limit": 7}
+        ["A", "X", "B", "Y", "Z", "C", "D"], {"expected": {"data": ["A", "B", "C"], "limit": 7}}
     )
     assert result.ok is True
     assert result.message is None
@@ -305,7 +305,7 @@ def test_op_sequence_in_order_basic_match() -> None:
 def test_op_sequence_in_order_out_of_order() -> None:
     """Test op_sequence_in_order with items out of order."""
     result = op_sequence_in_order(
-        ["A", "C", "B"], {"expected": ["A", "B", "C"], "limit": 3}
+        ["A", "C", "B"], {"expected": {"data": ["A", "B", "C"], "limit": 3}}
     )
     assert result.ok is False
     # When "A" is found, we look for "B" next, but "C" comes before "B"
@@ -317,7 +317,7 @@ def test_op_sequence_in_order_out_of_order() -> None:
 def test_op_sequence_in_order_missing_item() -> None:
     """Test op_sequence_in_order with missing item within limit."""
     result = op_sequence_in_order(
-        ["A", "B", "X", "Y", "Z"], {"expected": ["A", "B", "C"], "limit": 4}
+        ["A", "B", "X", "Y", "Z"], {"expected": {"data": ["A", "B", "C"], "limit": 4}}
     )
     assert result.ok is False
     assert "Expected item 'C' not found in order within first 4 items" in result.message
@@ -327,7 +327,7 @@ def test_op_sequence_in_order_missing_item() -> None:
 def test_op_sequence_in_order_limit_smaller_than_selection() -> None:
     """Test op_sequence_in_order with limit smaller than selection."""
     result = op_sequence_in_order(
-        ["A", "B", "C", "D", "E"], {"expected": ["A", "B"], "limit": 3}
+        ["A", "B", "C", "D", "E"], {"expected": {"data": ["A", "B"], "limit": 3}}
     )
     assert result.ok is True
     assert result.message is None
@@ -337,7 +337,7 @@ def test_op_sequence_in_order_limit_smaller_than_selection() -> None:
 def test_op_sequence_in_order_limit_larger_than_selection() -> None:
     """Test op_sequence_in_order with limit larger than selection."""
     result = op_sequence_in_order(
-        ["A", "B", "C"], {"expected": ["A", "B"], "limit": 100}
+        ["A", "B", "C"], {"expected": {"data": ["A", "B"], "limit": 100}}
     )
     assert result.ok is True
     assert result.message is None
@@ -346,7 +346,7 @@ def test_op_sequence_in_order_limit_larger_than_selection() -> None:
 
 def test_op_sequence_in_order_empty_expected() -> None:
     """Test op_sequence_in_order with empty expected list (should pass)."""
-    result = op_sequence_in_order(["A", "B", "C"], {"expected": [], "limit": 3})
+    result = op_sequence_in_order(["A", "B", "C"], {"expected": {"data": [], "limit": 3}})
     assert result.ok is True
     assert result.message is None
     assert result.got == ["A", "B", "C"]
@@ -354,7 +354,7 @@ def test_op_sequence_in_order_empty_expected() -> None:
 
 def test_op_sequence_in_order_empty_selection() -> None:
     """Test op_sequence_in_order with empty selection and non-empty expected."""
-    result = op_sequence_in_order([], {"expected": ["A", "B"], "limit": 10})
+    result = op_sequence_in_order([], {"expected": {"data": ["A", "B"], "limit": 10}})
     assert result.ok is False
     assert "Expected item 'A' not found within first 10 items" in result.message
     assert result.got == []
@@ -362,7 +362,7 @@ def test_op_sequence_in_order_empty_selection() -> None:
 
 def test_op_sequence_in_order_single_string_selection() -> None:
     """Test op_sequence_in_order with single string (auto-converts to list)."""
-    result = op_sequence_in_order("A", {"expected": ["A"], "limit": 5})
+    result = op_sequence_in_order("A", {"expected": {"data": ["A"], "limit": 5}})
     assert result.ok is True
     assert result.message is None
     assert result.got == ["A"]
@@ -370,21 +370,21 @@ def test_op_sequence_in_order_single_string_selection() -> None:
 
 def test_op_sequence_in_order_single_int_selection() -> None:
     """Test op_sequence_in_order with single int (auto-converts to list)."""
-    result = op_sequence_in_order(123, {"expected": ["123"], "limit": 5})
+    result = op_sequence_in_order(123, {"expected": {"data": ["123"], "limit": 5}})
     assert result.ok is True    
 
 
 def test_op_sequence_in_order_expected_not_list() -> None:
-    """Test op_sequence_in_order with expected not a list."""
-    result = op_sequence_in_order(["A", "B"], {"expected": "not a list", "limit": 5})
+    """Test op_sequence_in_order with expected not a dict."""
+    result = op_sequence_in_order(["A", "B"], {"expected": "not a dict"})
     assert result.ok is False
-    assert result.message == "Parameter 'expected' must be a list, got str"
+    assert result.message == "Parameter 'expected' must be a dict with 'data' and 'limit' fields, got str"
     assert result.got == ["A", "B"]
 
 
 def test_op_sequence_in_order_non_string_in_selection() -> None:
     """Test op_sequence_in_order with non-string items in selection."""
-    result = op_sequence_in_order([1, 2, 3], {"expected": ["A"], "limit": 3})
+    result = op_sequence_in_order([1, 2, 3], {"expected": {"data": ["A"], "limit": 3}})
     assert result.ok is False
     assert "Selection must be a list of strings, found int" in result.message
     assert result.got == [1, 2, 3]
@@ -392,31 +392,31 @@ def test_op_sequence_in_order_non_string_in_selection() -> None:
 
 def test_op_sequence_in_order_non_string_in_expected() -> None:
     """Test op_sequence_in_order with non-string items in expected."""
-    result = op_sequence_in_order(["A", "B"], {"expected": [1, 2], "limit": 3})
+    result = op_sequence_in_order(["A", "B"], {"expected": {"data": [1, 2], "limit": 3}})
     assert result.ok is False
-    assert "All items in 'expected' must be strings, found int" in result.message
+    assert "All items in 'expected.data' must be strings, found int" in result.message
     assert result.got == ["A", "B"]
 
 
 def test_op_sequence_in_order_negative_limit() -> None:
     """Test op_sequence_in_order with negative limit."""
-    result = op_sequence_in_order(["A", "B"], {"expected": ["A"], "limit": -1})
+    result = op_sequence_in_order(["A", "B"], {"expected": {"data": ["A"], "limit": -1}})
     assert result.ok is False
-    assert "Parameter 'limit' must be a positive integer, got -1" in result.message
+    assert "Parameter 'expected.limit' must be a positive integer, got -1" in result.message
     assert result.got == ["A", "B"]
 
 
 def test_op_sequence_in_order_zero_limit() -> None:
     """Test op_sequence_in_order with zero limit."""
-    result = op_sequence_in_order(["A", "B"], {"expected": ["A"], "limit": 0})
+    result = op_sequence_in_order(["A", "B"], {"expected": {"data": ["A"], "limit": 0}})
     assert result.ok is False
-    assert "Parameter 'limit' must be a positive integer, got 0" in result.message
+    assert "Parameter 'expected.limit' must be a positive integer, got 0" in result.message
     assert result.got == ["A", "B"]
 
 
 def test_op_sequence_in_order_single_item() -> None:
     """Test op_sequence_in_order with single expected item found."""
-    result = op_sequence_in_order(["X", "A", "Y"], {"expected": ["A"], "limit": 3})
+    result = op_sequence_in_order(["X", "A", "Y"], {"expected": {"data": ["A"], "limit": 3}})
     assert result.ok is True
     assert result.message is None
     assert result.got == ["X", "A", "Y"]
@@ -425,7 +425,7 @@ def test_op_sequence_in_order_single_item() -> None:
 def test_op_sequence_in_order_duplicate_items() -> None:
     """Test op_sequence_in_order with duplicate items in expected list."""
     result = op_sequence_in_order(
-        ["A", "X", "A", "Y", "A"], {"expected": ["A", "A", "A"], "limit": 5}
+        ["A", "X", "A", "Y", "A"], {"expected": {"data": ["A", "A", "A"], "limit": 5}}
     )
     assert result.ok is True
     assert result.message is None
@@ -434,15 +434,15 @@ def test_op_sequence_in_order_duplicate_items() -> None:
 
 def test_op_sequence_in_order_missing_expected_param() -> None:
     """Test op_sequence_in_order with missing 'expected' parameter."""
-    result = op_sequence_in_order(["A", "B"], {"limit": 5})
+    result = op_sequence_in_order(["A", "B"], {})
     assert result.ok is False
     assert result.message == "Missing required parameter 'expected'"
     assert result.got == ["A", "B"]
 
 
 def test_op_sequence_in_order_missing_limit_param() -> None:
-    """Test op_sequence_in_order with missing 'limit' parameter."""
-    result = op_sequence_in_order(["A", "B"], {"expected": ["A"]})
+    """Test op_sequence_in_order with missing 'limit' field in expected."""
+    result = op_sequence_in_order(["A", "B"], {"expected": {"data": ["A"]}})
     assert result.ok is False
-    assert result.message == "Missing required parameter 'limit'"
+    assert result.message == "Parameter 'expected' must contain 'limit' field"
     assert result.got == ["A", "B"]


### PR DESCRIPTION
## Problem

The `sequence_in_order` operator had a parameter structure mismatch between the README documentation and the actual implementation, causing the error:
```
"message": "Missing required parameter 'limit'"
```

The README showed usage as:
```yaml
- path: $.events[*].type
  op: sequence_in_order
  expected:
    - "START"
    - "PROCESSING"
  limit: 10  # ❌ Rejected by Pydantic
```

## Root Cause

1. `AssertRule` model only defines: `path`, `op`, `expected`, `where`, `all_`, `any_`, `not_`
2. Extra fields like `limit` are rejected by Pydantic
3. `Engine.eval_assert()` only passes `expected` to operators
4. The operator expected both `expected` and `limit` as separate params

## Solution

Changed `expected` to be a nested object containing both `data` and `limit`:

```yaml
- path: $.events[*].type
  op: sequence_in_order
  expected:
    data:
      - "START"
      - "PROCESSING"
    limit: 10  # ✅ Part of expected object
```

## Why This Approach

- ✅ Works with existing `AssertRule` model (`expected: Any` supports dicts)
- ✅ No changes needed to `Engine` 
- ✅ Consistent with architecture (only `expected` passed to operators)
- ✅ Type-safe and maintainable

## Changes

- **README.md**: Updated documentation and YAML examples
- **operators.py**: Extract `data` and `limit` from `expected` dict
- **tests/test_operators.py**: Updated all 18 test functions

## Testing

✅ All 85 tests pass

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)